### PR TITLE
Add functions for min/max and argmin/argmax along a matrix axis

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -8,11 +8,11 @@ Release 0.5.0 - (under development)
 * Switch to PEP 440 version numbering.
 * Replace distribute_setup.py with ez_setup.py.
 * Improve support for latest NVIDIA GPUs.
-* Direct links to online NVIDIA documentation in CUBLAS, CUFFT wrapper 
+* Direct links to online NVIDIA documentation in CUBLAS, CUFFT wrapper
   docstrings.
 * Add wrappers for CUSOLVER in CUDA 7.0.
 * Add skcuda namespace package that contains all modules in scikits.cuda namespace.
-* Add more wrappers for CUBLAS 5 functions (enh. by Teodor Moldovan, Sander 
+* Add more wrappers for CUBLAS 5 functions (enh. by Teodor Moldovan, Sander
   Dieleman).
 * Add support for CULA Dense Free R17 (enh. by Alex Rubinsteyn).
 * Memoize elementwise kernel used by ifft scaling (#37).
@@ -33,33 +33,35 @@ Release 0.5.0 - (under development)
 * Use cublas*copy in diag() function (enh. by Thomas Unterthiner).
 * Improved MacOSX compatibility (enh. by Michael M. Forbes).
 * Find CUBLAS version even when it is only accessible via LD_LIBRARY_PATH (enh. by Frédéric Bastien).
-* Get both major and minor version numbers from CUBLAS library when determining 
+* Get both major and minor version numbers from CUBLAS library when determining
   version.
 * Handle unset LD_LIBRARY_PATH variable (fix by Jan Schlüter).
 * Fix library search on MacOS X (fix by capdevc).
 * Fix library search on Windows.
 * Add Windows support to CULA wrappers.
-* Enable specification of memory pool allocator to linalg functions (enh.  by 
+* Enable specification of memory pool allocator to linalg functions (enh.  by
   Thomas Unterthiner).
 * Improve misc.select_block_grid_sizes() logic to handle different GPU hardware.
 * Compute transpose using CUDA 5.0 CUBLAS functions rather than with inefficient naive kernel.
 * Use ReadTheDocs theme when building HTML docs locally.
-* Support additional cufftPlanMany() parameters when creating FFT plans (enh. by 
+* Support additional cufftPlanMany() parameters when creating FFT plans (enh. by
   Gregory R. Lee).
 * Improved Python 3.4 compatibility (enh. by Eric Larson).
-* Avoid unnecessary import of cublas when importing fft module (enh. by Eric 
+* Avoid unnecessary import of cublas when importing fft module (enh. by Eric
   Larson).
 * Matrix trace function (enh. by Thomas Unterthiner).
-* Functions for computing simple axis-wise stats over matrices (enh. by Thomas 
+* Functions for computing simple axis-wise stats over matrices (enh. by Thomas
   Unterthiner).
-* Matrix add_dot, add_matvec, div_matvec, mult_matvec functions (enh. by Thomas 
+* Matrix add_dot, add_matvec, div_matvec, mult_matvec functions (enh. by Thomas
   Unterthiner).
-* Faster dot_diag implementation using CUBLAS matrix-matrix multiplication (enh.  
+* Faster dot_diag implementation using CUBLAS matrix-matrix multiplication (enh.
   by Thomas Unterthiner).
-* Memoize SourceModule calls to speed up various high-level functions (enh. by 
+* Memoize SourceModule calls to speed up various high-level functions (enh. by
   Thomas Unterthiner).
 * Function for computing matrix determinant (enh. by Thomas Unterthiner).
-  
+* Function for computing min/max and argmin/argmax along a matrix axis
+  (enh. by Thomas Unterthiner).
+
 Release 0.042 - (March 10, 2013)
 --------------------------------
 * Add complex exponential integral.
@@ -67,7 +69,7 @@ Release 0.042 - (March 10, 2013)
 * Use CUBLAS v2 API, add preliminary support for CUBLAS 5 functions.
 * Detect CUBLAS version without initializing the GPU.
 * Work around numpy bug #1898.
-* Fix issues with pycuda installations done via easy_install/pip. 
+* Fix issues with pycuda installations done via easy_install/pip.
 * Add support for specifying streams when creating FFT plans.
 * Successfully find CULA R13a libraries.
 * Raise exceptions when functions in the full release of CULA Dense are invoked
@@ -115,4 +117,3 @@ Release 0.02 - (September 21, 2010)
 Release 0.01 - (September 17, 2010)
 -----------------------------------
 * First public release.
-

--- a/docs/source/reference_misc.rst
+++ b/docs/source/reference_misc.rst
@@ -9,6 +9,8 @@ Miscellaneous Routines
    :nosignatures:
 
    add_matvec
+   argmax
+   argmin
    cumsum
    diff
    done_context
@@ -22,8 +24,10 @@ Miscellaneous Routines
    init_device
    iscomplextype
    isdoubletype
+   max
    maxabs
    mean
+   min
    ones
    ones_like
    select_block_grid_sizes

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -308,6 +308,50 @@ class test_misc(TestCase):
     def test_std_complex128(self):
         self.impl_test_std(np.complex128)
 
+    def _impl_test_minmax(self, dtype):
+        x = np.random.normal(scale=5.0, size=(3, 5))
+        x = x.astype(dtype=dtype, order='C')
+        x_gpu = gpuarray.to_gpu(x)
+        assert np.allclose(misc.max(x_gpu, axis=0).get(), x.max(axis=0))
+        assert np.allclose(misc.max(x_gpu, axis=1).get(), x.max(axis=1))
+        assert np.allclose(misc.min(x_gpu, axis=0).get(), x.min(axis=0))
+        assert np.allclose(misc.min(x_gpu, axis=1).get(), x.min(axis=1))
+
+        x = x.astype(dtype=dtype, order='F')
+        x_gpu = gpuarray.to_gpu(x)
+        assert np.allclose(misc.max(x_gpu, axis=0).get(), x.max(axis=0))
+        assert np.allclose(misc.max(x_gpu, axis=1).get(), x.max(axis=1))
+        assert np.allclose(misc.min(x_gpu, axis=0).get(), x.min(axis=0))
+        assert np.allclose(misc.min(x_gpu, axis=1).get(), x.min(axis=1))
+
+    def test_minmax_float32(self):
+        self._impl_test_minmax(np.float32)
+
+    def test_minmax_float64(self):
+        self._impl_test_minmax(np.float64)
+
+    def _impl_test_argminmax(self, dtype):
+        x = np.random.normal(scale=5.0, size=(3, 5))
+        x = x.astype(dtype=dtype, order='C')
+        x_gpu = gpuarray.to_gpu(x)
+        assert np.allclose(misc.argmax(x_gpu, axis=0).get(), x.argmax(axis=0))
+        assert np.allclose(misc.argmax(x_gpu, axis=1).get(), x.argmax(axis=1))
+        assert np.allclose(misc.argmin(x_gpu, axis=0).get(), x.argmin(axis=0))
+        assert np.allclose(misc.argmin(x_gpu, axis=1).get(), x.argmin(axis=1))
+
+        x = x.astype(dtype=dtype, order='F')
+        x_gpu = gpuarray.to_gpu(x)
+        assert np.allclose(misc.argmax(x_gpu, axis=0).get(), x.argmax(axis=0))
+        assert np.allclose(misc.argmax(x_gpu, axis=1).get(), x.argmax(axis=1))
+        assert np.allclose(misc.argmin(x_gpu, axis=0).get(), x.argmin(axis=0))
+        assert np.allclose(misc.argmin(x_gpu, axis=1).get(), x.argmin(axis=1))
+
+    def test_argminmax_float32(self):
+        self._impl_test_argminmax(np.float32)
+
+    def test_argminmax_float64(self):
+        self._impl_test_argminmax(np.float64)
+
 def suite():
     s = TestSuite()
     s.addTest(test_misc('test_maxabs_float32'))
@@ -329,6 +373,8 @@ def suite():
     s.addTest(test_misc('test_var_complex64'))
     s.addTest(test_misc('test_std_float32'))
     s.addTest(test_misc('test_std_complex64'))
+    s.addTest(test_misc('test_minmax_float32'))
+    s.addTest(test_misc('test_argminmax_float32'))
     if misc.get_compute_capability(pycuda.autoinit.device) >= 1.3:
         s.addTest(test_misc('test_maxabs_float64'))
         s.addTest(test_misc('test_maxabs_complex128'))
@@ -349,6 +395,8 @@ def suite():
         s.addTest(test_misc('test_var_complex128'))
         s.addTest(test_misc('test_std_float64'))
         s.addTest(test_misc('test_std_complex128'))
+    s.addTest(test_misc('test_minmax_float64'))
+    s.addTest(test_misc('test_argminmax_float64'))
     return s
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds `scikits.cuda.misc.min` (`max`, `argmin`, `argmax`) functions that compute the minimum/maximum and argmax/argmin along a given matrix axis, similar to `np.max`/`min`/`argmax`/`argmin`. 

The functions only works on real number types, because the semantics of  '>' and '<' (and consequently min/max) aren't clear to me for complex types. This is different from numpy, where min/max/argmax/argmin can be computed for complex matrices. 

I took the liberty of adding the things to CHANGES.txt and to the docs (I've noticed you always had to do that on your own after merging).