### PR TITLE
Consistent 'overwrite' default in skcuda.linalg

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -61,6 +61,8 @@ Release 0.5.0 - (under development)
 * Function for computing matrix determinant (enh. by Thomas Unterthiner).
 * Function for computing min/max and argmin/argmax along a matrix axis
   (enh. by Thomas Unterthiner).
+* Set default value of the parameter 'overwrite' to False in all linalg
+  functions.
 
 Release 0.042 - (March 10, 2013)
 --------------------------------

--- a/scikits/cuda/linalg.py
+++ b/scikits/cuda/linalg.py
@@ -692,7 +692,7 @@ def mdot(*args, **kwargs):
         del(temp_gpu)
     return out_gpu
 
-def dot_diag(d_gpu, a_gpu, trans='N', overwrite=True, handle=None):
+def dot_diag(d_gpu, a_gpu, trans='N', overwrite=False, handle=None):
     """
     Dot product of diagonal and non-diagonal arrays.
 
@@ -709,8 +709,8 @@ def dot_diag(d_gpu, a_gpu, trans='N', overwrite=True, handle=None):
         as `d_gpu`.
     trans : char
         If 'T', compute the product of the transpose of `a_gpu`.
-    overwrite : bool
-        If true (default), save the result in `a_gpu`.
+    overwrite : bool (default: False)
+        If true, save the result in `a_gpu`.
     handle : int
         CUBLAS context. If no context is specified, the default handle from
         `scikits.cuda.misc._global_cublas_handle` is used.
@@ -787,7 +787,7 @@ def dot_diag(d_gpu, a_gpu, trans='N', overwrite=True, handle=None):
                 d_gpu.gpudata, 1, r_gpu.gpudata, ldr)
     return r_gpu
 
-def add_diag(d_gpu, a_gpu, overwrite=True, handle=None):
+def add_diag(d_gpu, a_gpu, overwrite=False, handle=None):
     """
     Adds a vector to the diagonal of an array.
 
@@ -800,8 +800,8 @@ def add_diag(d_gpu, a_gpu, overwrite=True, handle=None):
         diagonal.
     a_gpu : pycuda.gpuarray.GPUArray
         Summand array with shape `(N, N)`.
-    overwrite : bool
-        If true, save the result in `a_gpu` (default: True).
+    overwrite : bool (default: False)
+        If true, save the result in `a_gpu`.
     handle : int
         CUBLAS context. If no context is specified, the default handle from
         `scikits.cuda.misc._global_cublas_handle` is used.
@@ -965,7 +965,7 @@ def hermitian(a_gpu, handle=None):
 
     return _transpose(a_gpu, True, handle)
 
-def conj(x_gpu, overwrite=True):
+def conj(x_gpu, overwrite=False):
     """
     Complex conjugate.
 
@@ -975,8 +975,8 @@ def conj(x_gpu, overwrite=True):
     ----------
     x_gpu : pycuda.gpuarray.GPUArray
         Input array of shape `(m, n)`.
-    overwrite : bool
-        If true (default), save the result in the specified array.
+    overwrite : bool (default: False)
+        If true, save the result in the specified array.
         If false, return the result in a newly allocated array.
 
     Returns
@@ -1338,7 +1338,7 @@ def _get_tril_kernel(use_double, use_complex, cols):
     return mod.get_function("tril")
 
 
-def tril(a_gpu, overwrite=True, handle=None):
+def tril(a_gpu, overwrite=False, handle=None):
     """
     Lower triangle of a matrix.
 
@@ -1348,8 +1348,8 @@ def tril(a_gpu, overwrite=True, handle=None):
     ----------
     a_gpu : pycuda.gpuarray.GPUArray
         Input matrix of shape `(m, m)`
-    overwrite : boolean
-        If true (default), zero out the upper triangle of the matrix.
+    overwrite : bool (default: False)
+        If true, zero out the upper triangle of the matrix.
         If false, return the result in a newly allocated matrix.
     handle : int
         CUBLAS context. If no context is specified, the default handle from
@@ -1429,7 +1429,7 @@ def tril(a_gpu, overwrite=True, handle=None):
         swap_func(handle, a_gpu.size, int(a_gpu.gpudata), 1, int(a_orig_gpu.gpudata), 1)
         return a_orig_gpu
 
-def multiply(x_gpu, y_gpu, overwrite=True):
+def multiply(x_gpu, y_gpu, overwrite=False):
     """
     Multiply arguments element-wise.
 
@@ -1439,8 +1439,8 @@ def multiply(x_gpu, y_gpu, overwrite=True):
         Input arrays to be multiplied.
     dev : pycuda.driver.Device
         Device object to be used.
-    overwrite : bool
-        If true (default), return the result in `y_gpu`.
+    overwrite : bool (default: False)
+        If true, return the result in `y_gpu`.
         is false, return the result in a newly allocated array.
 
     Returns
@@ -1613,8 +1613,8 @@ def inv(a_gpu, overwrite=False, ipiv_gpu=None):
     ----------
     a_gpu : pycuda.gpuarray.GPUArray
         Square (n, n) matrix to be inverted.
-    overwrite : bool, optional
-        Discard data in `a` (may improve performance). Default is False.
+    overwrite : bool (default: False)
+        Discard data in `a` (may improve performance).
     ipiv_gpu : pycuda.gpuarray.GPUArray (optional)
         Temporary array of size n, can be supplied to save allocations.
 
@@ -1716,8 +1716,8 @@ def det(a_gpu, overwrite=False, ipiv_gpu=None, handle=None):
     ----------
     a_gpu : pycuda.gpuarray.GPUArray
         The square n*n matrix of which to calculate the determinant.
-    overwrite : bool, optional
-        Discard data in `a` (may improve performance). Default is False.
+    overwrite : bool (default: False)
+        Discard data in `a` (may improve performance).
     handle : int
         CUBLAS context. If no context is specified, the default handle from
         `scikits.misc._global_cublas_handle` is used.

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -273,7 +273,8 @@ class test_linalg(TestCase):
         a = a.astype(dtype, order="F", copy=True)
         d_gpu = gpuarray.to_gpu(d)
         a_gpu = gpuarray.to_gpu(a)
-        r_gpu = linalg.dot_diag(d_gpu, a_gpu)
+        # note: due to pycuda issue #66, this will fail when overwrite=False
+        r_gpu = linalg.dot_diag(d_gpu, a_gpu, overwrite=True)
         assert np.allclose(np.dot(np.diag(d), a), r_gpu.get())
 
     def test_dot_diag_float32(self):
@@ -298,7 +299,8 @@ class test_linalg(TestCase):
         a = a.astype(dtype, order="F", copy=True)
         d_gpu = gpuarray.to_gpu(d)
         a_gpu = gpuarray.to_gpu(a)
-        r_gpu = linalg.dot_diag(d_gpu, a_gpu, 't')
+        # note: due to pycuda issue #66, this will fail when overwrite=False
+        r_gpu = linalg.dot_diag(d_gpu, a_gpu, 't', overwrite=True)
         assert np.allclose(np.dot(np.diag(d), a.T).T, r_gpu.get())
 
     def test_dot_diag_t_float32(self):
@@ -429,15 +431,15 @@ class test_linalg(TestCase):
         a = np.array([[1+1j, 2-2j, 3+3j, 4-4j],
                       [5+5j, 6-6j, 7+7j, 8-8j]], np.complex64)
         a_gpu = gpuarray.to_gpu(a)
-        linalg.conj(a_gpu)
-        assert np.all(np.conj(a) == a_gpu.get())
+        r_gpu = linalg.conj(a_gpu)
+        assert np.all(np.conj(a) == r_gpu.get())
 
     def test_conj_complex128(self):
         a = np.array([[1+1j, 2-2j, 3+3j, 4-4j],
                       [5+5j, 6-6j, 7+7j, 8-8j]], np.complex128)
         a_gpu = gpuarray.to_gpu(a)
-        linalg.conj(a_gpu)
-        assert np.all(np.conj(a) == a_gpu.get())
+        r_gpu = linalg.conj(a_gpu)
+        assert np.all(np.conj(a) == r_gpu.get())
 
     def test_diag_1d_float32(self):
         v = np.array([1, 2, 3, 4, 5, 6], np.float32)


### PR DESCRIPTION
The default value for the `overwrite` parameter is now always False by default, as discussed in #110 .