### PR TITLE
Added some new MAGMA functions to the wrapper

### DIFF
--- a/scikits/cuda/magma.py
+++ b/scikits/cuda/magma.py
@@ -22,7 +22,7 @@ else:
     raise RuntimeError('unsupported platform')
 
 _load_err = ''
-for _lib in  _libmagma_libname_list:
+for _lib in _libmagma_libname_list:
     try:
         _libmagma = ctypes.cdll.LoadLibrary(_lib)
     except OSError:
@@ -36,6 +36,10 @@ if _load_err:
 # Exceptions corresponding to various MAGMA errors:
 _libmagma.magma_strerror.restype = ctypes.c_char_p
 _libmagma.magma_strerror.argtypes = [ctypes.c_int]
+# MAGMA below 1.4.0 uses "L" and "U" to select upper/lower triangular
+# matrices, MAGMA 1.5+ uses numeric constants. This dict will be filled
+# in magma_init() and will convert between the two modes accordingly
+_uplo_conversion = {}
 def magma_strerror(error):
     """
     Return string corresponding to specified MAGMA error code.
@@ -50,153 +54,86 @@ class magmaError(Exception):
         pass
     pass
 
-class magmaNotInitialized(magmaError):
-    try:
-        __doc__ = magma_strerror(-101)
-    except:
-        pass
+class MagmaError(Exception):
+	def __init__(self, status, info=None):
+		self._status = status
+		self._info = info
+		errstr = "%s (Code: %d)" % (magma_strerror(status), status)
+		super(MagmaError,self).__init__(errstr)
+
+class MagmaNotInitializedError(MagmaError):
     pass
 
-class magmaReinitialized(magmaError):
-    try:
-        __doc__ = magma_strerror(-102)
-    except:
-        pass
+class MagmaReinitializedError(MagmaError):
     pass
 
-class magmaNotSupported(magmaError):
-    try:
-        __doc__ = magma_strerror(-103)
-    except:
-        pass
+class MagmaNotSupportedError(MagmaError):
     pass
 
-class magmaIllegalValue(magmaError):
-    try:
-        __doc__ = magma_strerror(-104)
-    except:
-        pass
+class MagmaIllegalValueError(MagmaError):
     pass
 
-class magmaIllegalValue(magmaError):
-    try:
-        __doc__ = magma_strerror(-104)
-    except:
-        pass
+class MagmaIllegalValueError(MagmaError):
     pass
 
-class magmaNotFound(magmaError):
-    try:
-        __doc__ = magma_strerror(-105)
-    except:
-        pass
+class MagmaNotFoundError(MagmaError):
     pass
 
-class magmaAllocation(magmaError):
-    try:
-        __doc__ = magma_strerror(-106)
-    except:
-        pass
+class MagmaAllocationError(MagmaError):
     pass
 
-class magmaInternalLimit(magmaError):
-    try:
-        __doc__ = magma_strerror(-107)
-    except:
-        pass
+class MagmaInternalLimitError(MagmaError):
     pass
 
-class magmaUnallocated(magmaError):
-    try:
-        __doc__ = magma_strerror(-108)
-    except:
-        pass
+class MagmaUnallocatedError(MagmaError):
     pass
 
-class magmaFilesystem(magmaError):
-    try:
-        __doc__ = magma_strerror(-109)
-    except:
-        pass
+class MagmaFilesystemError(MagmaError):
     pass
 
-class magmaUnexpected(magmaError):
-    try:
-        __doc__ = magma_strerror(-110)
-    except:
-        pass
-    pass
- 
-class magmaSequenceFlushed(magmaError):
-    try:
-        __doc__ = magma_strerror(-111)
-    except:
-        pass
+class MagmaUnexpectedError(MagmaError):
     pass
 
-class magmaHostAlloc(magmaError):
-    try:
-        __doc__ = magma_strerror(-112)
-    except:
-        pass
-    pass
-  
-class magmaDeviceAlloc(magmaError):
-    try:
-        __doc__ = magma_strerror(-113)
-    except:
-        pass
+class MagmaSequenceFlushedError(MagmaError):
     pass
 
-class magmaCUDAStream(magmaError):
-    try:
-        __doc__ = magma_strerror(-114)
-    except:
-        pass
+class MagmaHostAllocError(MagmaError):
     pass
 
-class magmaInvalidPtr(magmaError):
-    try:
-        __doc__ = magma_strerror(-115)
-    except:
-        pass
+class MagmaDeviceAllocError(MagmaError):
     pass
 
-class magmaUnknown(magmaError):
-    try:
-        __doc__ = magma_strerror(-116)
-    except:
-        pass
+class MagmaCUDAStreamError(MagmaError):
     pass
 
-class magmaNotImplemented(magmaError):
-    try:
-        __doc__ = magma_strerror(-117)
-    except:
-        pass
+class MagmaInvalidPtrError(MagmaError):
+    pass
+
+class MagmaUnknownError(MagmaError):
     pass
 
 magmaExceptions = {
-    -100: magmaError,
-    -101: magmaNotInitialized,
-    -102: magmaReinitialized,
-    -103: magmaNotSupported,
-    -104: magmaIllegalValue,
-    -105: magmaNotFound,
-    -106: magmaAllocation,
-    -107: magmaInternalLimit,
-    -108: magmaUnallocated,
-    -109: magmaFilesystem,
-    -110: magmaUnexpected,
-    -111: magmaSequenceFlushed,
-    -112: magmaHostAlloc,
-    -113: magmaDeviceAlloc,
-    -114: magmaCUDAStream,
-    -115: magmaInvalidPtr,
-    -116: magmaUnknown,
-    -117: magmaNotImplemented
+    -100: MagmaError,
+    -101: MagmaNotInitializedError,
+    -102: MagmaReinitializedError,
+    -103: MagmaNotSupportedError,
+    -104: MagmaIllegalValueError,
+    -105: MagmaNotFoundError,
+    -106: MagmaAllocationError,
+    -107: MagmaInternalLimitError,
+    -108: MagmaUnallocatedError,
+    -109: MagmaFilesystemError,
+    -110: MagmaUnexpectedError,
+    -111: MagmaSequenceFlushedError,
+    -112: MagmaHostAllocError,
+    -113: MagmaDeviceAllocError,
+    -114: MagmaCUDAStreamError,
+    -115: MagmaInvalidPtrError,
+    -116: MagmaUnknownError
 }
 
+_libmagma.magma_uplo_const.restype = ctypes.c_int
+_libmagma.magma_uplo_const.argtypes = [ctypes.c_char]
 def magmaCheckStatus(status):
     """
     Raise an exception corresponding to the specified MAGMA status code.
@@ -204,11 +141,25 @@ def magmaCheckStatus(status):
 
     if status != 0:
         try:
-            raise magmaExceptions[status]
+            raise magmaExceptions[status](status)
         except KeyError:
-            raise magmaError
+            raise MagmaError(status)
 
 # Utility functions:
+_libmagma.magma_version.argtypes = [ctypes.c_void_p,
+    ctypes.c_void_p, ctypes.c_void_p]
+
+
+def magma_version():
+    """
+    Get MAGMA version.
+    """
+    majv = ctypes.c_int()
+    minv = ctypes.c_int()
+    micv = ctypes.c_int()
+    _libmagma.magma_version(ctypes.byref(majv),
+        ctypes.byref(minv), ctypes.byref(micv))
+    return (majv.value, minv.value, micv.value)
 
 _libmagma.magma_init.restype = int
 def magma_init():
@@ -216,8 +167,17 @@ def magma_init():
     Initialize MAGMA.
     """
 
+    global _uplo_conversion
     status = _libmagma.magma_init()
     magmaCheckStatus(status)
+    v = magma_version()
+    if v >= (1, 5, 0):
+        _uplo_conversion.update({"L": _libmagma.magma_uplo_const("L"),
+                                 "l": _libmagma.magma_uplo_const("l"),
+                                 "U": _libmagma.magma_uplo_const("U"),
+                                 "u": _libmagma.magma_uplo_const("u")})
+    else:
+       _uplo_conversion.update({"L": "L", "l": "l", "U": "u", "u": "u"})
 
 _libmagma.magma_finalize.restype = int
 def magma_finalize():
@@ -440,7 +400,7 @@ def magma_caxpy(n, alpha, dx, incx, dy, incy):
     """
 
     _libmagma.magma_caxpy(n, ctypes.byref(cuda.cuFloatComplex(alpha.real,
-                                                              alpha.imag)), 
+                                                              alpha.imag)),
                           int(dx), incx, int(dy), incy)
 
 _libmagma.magma_zaxpy.restype = int
@@ -456,7 +416,7 @@ def magma_zaxpy(n, alpha, dx, incx, dy, incy):
     """
 
     _libmagma.magma_zaxpy(n, ctypes.byref(cuda.cuDoubleComplex(alpha.real,
-                                                               alpha.imag)), 
+                                                               alpha.imag)),
                           int(dx), incx, int(dy), incy)
 
 # SCOPY, DCOPY, CCOPY, ZCOPY
@@ -667,10 +627,10 @@ def magma_srotm(n, dx, incx, dy, incy, param):
 
 # SROTMG, DROTMG
 _libmagma.magma_srotmg.argtypes = [ctypes.c_void_p,
-                                  ctypes.c_void_p,
-                                  ctypes.c_void_p,
-                                  ctypes.c_void_p,
-                                  ctypes.c_void_p]
+                                   ctypes.c_void_p,
+                                   ctypes.c_void_p,
+                                   ctypes.c_void_p,
+                                   ctypes.c_void_p]
 def magma_srotmg(d1, d2, x1, y1, param):
     """
     Construct a real modified Givens rotation matrix.
@@ -770,16 +730,16 @@ def magma_ssyr(uplo, n, alpha, dx, incx, dA, ldda):
 
 # SSYR2, DSYR2, CSYR2, ZSYR2
 _libmagma.magma_ssyr2.argtypes = [ctypes.c_char,
-                                 ctypes.c_int,
-                                 ctypes.c_float,
-                                 ctypes.c_void_p,
-                                 ctypes.c_int,
-                                 ctypes.c_void_p,
-                                 ctypes.c_int,
-                                 ctypes.c_void_p,
-                                 ctypes.c_int]
+                                  ctypes.c_int,
+                                  ctypes.c_float,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int]
 def magma_ssyr2(uplo, n, alpha, dx, incx, dy, incy, dA, ldda):
-    _libmagma.magma_ssyr2(uplo, n, alpha, int(dx), incx, 
+    _libmagma.magma_ssyr2(uplo, n, alpha, int(dx), incx,
                           int(dy), incy, int(dA), ldda)
 
 # STRMV, DTRMV, CTRMV, ZTRMV
@@ -794,7 +754,7 @@ _libmagma.magma_strmv.argtypes = [ctypes.c_char,
 def magma_strmv(uplo, trans, diag, n,
                 dA, ldda, dx, incx):
     _libmagma.magma_strmv(uplo, trans, diag, n,
-                          int(dA), ldda, int(dx), incx)                          
+                          int(dA), ldda, int(dx), incx)
 
 # STRSV, DTRSV, CTRSV, ZTRSV
 _libmagma.magma_strsv.argtypes = [ctypes.c_char,
@@ -808,7 +768,7 @@ _libmagma.magma_strsv.argtypes = [ctypes.c_char,
 def magma_strsv(uplo, trans, diag, n,
                 dA, ldda, dx, incx):
     _libmagma.magma_strsv(uplo, trans, diag, n,
-                          int(dA), ldda, int(dx), incx)                          
+                          int(dA), ldda, int(dx), incx)
 
 # SGEMM, DGEMM, CGEMM, ZGEMM
 _libmagma.magma_sgemm.argtypes = [ctypes.c_char,
@@ -826,7 +786,7 @@ _libmagma.magma_sgemm.argtypes = [ctypes.c_char,
                                   ctypes.c_int]
 def magma_sgemm(transA, transB, m, n, k, alpha, dA, ldda, dB, lddb, beta,
                 dC, lddc):
-    _libmagma.magma_sgemm(transA, transB, m, n, k, alpha, 
+    _libmagma.magma_sgemm(transA, transB, m, n, k, alpha,
                           int(dA), ldda, int(dB), lddb,
                           beta, int(dC), lddc)
 
@@ -845,10 +805,10 @@ _libmagma.magma_zgemm.argtypes = [ctypes.c_char,
                                   ctypes.c_int]
 def magma_zgemm(transA, transB, m, n, k, alpha, dA, ldda, dB, lddb, beta,
                 dC, lddc):
-    _libmagma.magma_zgemm(transA, transB, m, n, k, alpha, 
+    _libmagma.magma_zgemm(transA, transB, m, n, k, alpha,
                           int(dA), ldda, int(dB), lddb,
                           beta, int(dC), lddc)
-    
+
 
 # SSYMM, DSYMM, CSYMM, ZSYMM
 _libmagma.magma_ssymm.argtypes = [ctypes.c_char,
@@ -865,7 +825,7 @@ _libmagma.magma_ssymm.argtypes = [ctypes.c_char,
                                   ctypes.c_int]
 def magma_ssymm(side, uplo, m, n, alpha, dA, ldda, dB, lddb, beta,
                 dC, lddc):
-    _libmagma.magma_ssymm(side, uplo, m, n, alpha, 
+    _libmagma.magma_ssymm(side, uplo, m, n, alpha,
                           int(dA), ldda, int(dB), lddb,
                           beta, int(dC), lddc)
 
@@ -882,7 +842,7 @@ _libmagma.magma_ssyrk.argtypes = [ctypes.c_char,
                                   ctypes.c_int]
 def magma_ssyrk(uplo, trans, n, k, alpha, dA, ldda, beta,
                 dC, lddc):
-    _libmagma.magma_ssyrk(uplo, trans, n, k, alpha, 
+    _libmagma.magma_ssyrk(uplo, trans, n, k, alpha,
                           int(dA), ldda, beta, int(dC), lddc)
 
 # SSYR2K, DSYR2K, CSYR2K, ZSYR2K
@@ -898,10 +858,10 @@ _libmagma.magma_ssyr2k.argtypes = [ctypes.c_char,
                                    ctypes.c_float,
                                    ctypes.c_void_p,
                                    ctypes.c_int]
-def magma_ssyr2k(uplo, trans, n, k, alpha, dA, ldda, 
-                 dB, lddb, beta, dC, lddc):                
-    _libmagma.magma_ssyr2k(uplo, trans, n, k, alpha, 
-                           int(dA), ldda, int(dB), lddb, 
+def magma_ssyr2k(uplo, trans, n, k, alpha, dA, ldda,
+                 dB, lddb, beta, dC, lddc):
+    _libmagma.magma_ssyr2k(uplo, trans, n, k, alpha,
+                           int(dA), ldda, int(dB), lddb,
                            beta, int(dC), lddc)
 
 # STRMM, DTRMM, CTRMM, ZTRMM
@@ -916,9 +876,9 @@ _libmagma.magma_strmm.argtypes = [ctypes.c_char,
                                   ctypes.c_int,
                                   ctypes.c_void_p,
                                   ctypes.c_int]
-def magma_strmm(side, uplo, trans, diag, m, n, alpha, dA, ldda, 
-                dB, lddb):                
-    _libmagma.magma_strmm(uplo, trans, diag, m, n, alpha, 
+def magma_strmm(side, uplo, trans, diag, m, n, alpha, dA, ldda,
+                dB, lddb):
+    _libmagma.magma_strmm(uplo, trans, diag, m, n, alpha,
                           int(dA), ldda, int(dB), lddb)
 
 # STRSM, DTRSM, CTRSM, ZTRSM
@@ -933,9 +893,9 @@ _libmagma.magma_strsm.argtypes = [ctypes.c_char,
                                   ctypes.c_int,
                                   ctypes.c_void_p,
                                   ctypes.c_int]
-def magma_strsm(side, uplo, trans, diag, m, n, alpha, dA, ldda, 
-                dB, lddb):                
-    _libmagma.magma_strsm(uplo, trans, diag, m, n, alpha, 
+def magma_strsm(side, uplo, trans, diag, m, n, alpha, dA, ldda,
+                dB, lddb):
+    _libmagma.magma_strsm(uplo, trans, diag, m, n, alpha,
                           int(dA), ldda, int(dB), lddb)
 
 
@@ -1078,9 +1038,9 @@ def magma_sgehrd2(n, ilo, ihi, A, lda, tau,
     """
     Reduce matrix to upper Hessenberg form.
     """
-    
+
     status = _libmagma.magma_sgehrd2(n, ilo, ihi, int(A), lda,
-                                     int(tau), int(work), 
+                                     int(tau), int(work),
                                      lwork, int(info))
     magmaCheckStatus(status)
 
@@ -1100,9 +1060,9 @@ def magma_sgehrd(n, ilo, ihi, A, lda, tau,
     """
     Reduce matrix to upper Hessenberg form (fast algorithm).
     """
-    
+
     status = _libmagma.magma_sgehrd(n, ilo, ihi, int(A), lda,
-                                    int(tau), int(work), 
+                                    int(tau), int(work),
                                     lwork, int(dT), int(info))
     magmaCheckStatus(status)
 
@@ -1117,13 +1077,13 @@ _libmagma.magma_sgelqf.argtypes = [ctypes.c_int,
                                    ctypes.c_int,
                                    ctypes.c_void_p]
 def magma_sgelqf(m, n, A, lda, tau, work, lwork, info):
-                 
+
     """
     LQ factorization.
     """
-    
+
     status = _libmagma.magma_sgelqf(m, n, int(A), lda,
-                                    int(tau), int(work), 
+                                    int(tau), int(work),
                                     lwork, int(info))
     magmaCheckStatus(status)
 
@@ -1138,13 +1098,13 @@ _libmagma.magma_sgeqrf.argtypes = [ctypes.c_int,
                                    ctypes.c_int,
                                    ctypes.c_void_p]
 def magma_sgeqrf(m, n, A, lda, tau, work, lwork, info):
-                 
+
     """
     QR factorization.
     """
-    
+
     status = _libmagma.magma_sgeqrf(m, n, int(A), lda,
-                                    int(tau), int(work), 
+                                    int(tau), int(work),
                                     lwork, int(info))
     magmaCheckStatus(status)
 
@@ -1160,13 +1120,13 @@ _libmagma.magma_sgeqrf4.argtypes = [ctypes.c_int,
                                     ctypes.c_int,
                                     ctypes.c_void_p]
 def magma_sgeqrf4(num_gpus, m, n, a, lda, tau, work, lwork, info):
-                 
+
     """
 
     """
-    
+
     status = _libmagma.magma_sgeqrf4(num_gpus, m, n, int(a), lda,
-                                    int(tau), int(work), 
+                                    int(tau), int(work),
                                     lwork, int(info))
     magmaCheckStatus(status)
 
@@ -1181,13 +1141,13 @@ _libmagma.magma_sgeqrf_ooc.argtypes = [ctypes.c_int,
                                        ctypes.c_int,
                                        ctypes.c_void_p]
 def magma_sgeqrf_ooc(m, n, A, lda, tau, work, lwork, info):
-                 
+
     """
     QR factorization (ooc).
     """
-    
+
     status = _libmagma.magma_sgeqrf_ooc(m, n, int(A), lda,
-                                        int(tau), int(work), 
+                                        int(tau), int(work),
                                         lwork, int(info))
     magmaCheckStatus(status)
 
@@ -1202,13 +1162,13 @@ _libmagma.magma_sgesv.argtypes = [ctypes.c_int,
                                   ctypes.c_int,
                                   ctypes.c_void_p]
 def magma_sgesv(n, nhrs, A, lda, ipiv, B, ldb, info):
-                 
+
     """
     Solve system of linear equations.
     """
-    
+
     status = _libmagma.magma_sgesv(n, nhrs, int(A), lda,
-                                   int(ipiv), int(B), 
+                                   int(ipiv), int(B),
                                    ldb, int(info))
     magmaCheckStatus(status)
 
@@ -1221,13 +1181,13 @@ _libmagma.magma_sgetrf.argtypes = [ctypes.c_int,
                                    ctypes.c_void_p,
                                    ctypes.c_void_p]
 def magma_sgetrf(m, n, A, lda, ipiv, info):
-                 
+
     """
     LU factorization.
     """
-    
+
     status = _libmagma.magma_sgetrf(m, n, int(A), lda,
-                                    int(ipiv), int(info))   
+                                    int(ipiv), int(info))
     magmaCheckStatus(status)
 
 ## SGETRF2, DGETRF2, CGETRF2, ZGETRF2
@@ -1239,11 +1199,11 @@ def magma_sgetrf(m, n, A, lda, ipiv, info):
 #                                    ctypes.c_void_p,
 #                                    ctypes.c_void_p]
 #def magma_sgetrf2(m, n, A, lda, ipiv, info):
-#                 
+#
 #    """
 #    LU factorization (multi-GPU).
 #    """
-#    
+#
 #    status = _libmagma.magma_sgetrf2(m, n, int(A), lda,
 #                                    int(ipiv), int(info))
 #    magmaCheckStatus(status)
@@ -1266,13 +1226,13 @@ _libmagma.magma_sgeev.argtypes = [ctypes.c_char,
                                   ctypes.c_void_p]
 def magma_sgeev(jobvl, jobvr, n, a, lda,
                 w, vl, ldvl, vr, ldvr, work, lwork, rwork, info):
-                 
+
     """
     Compute eigenvalues and eigenvectors.
     """
 
     status = _libmagma.magma_sgeev(jobvl, jobvr, n, int(a), lda,
-                                   int(w), int(vl), ldvl, int(vr), ldvr, 
+                                   int(w), int(vl), ldvl, int(vr), ldvr,
                                    int(work), lwork, int(rwork), int(info))
     magmaCheckStatus(status)
 
@@ -1298,9 +1258,9 @@ def magma_sgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SVD decomposition.
     """
 
-    status = _libmagma.magma_sgesvd(jobu, jobvt, m, n, 
+    status = _libmagma.magma_sgesvd(jobu, jobvt, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(info))
     magmaCheckStatus(status)
 
@@ -1325,9 +1285,9 @@ def magma_dgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SVD decomposition.
     """
 
-    status = _libmagma.magma_dgesvd(jobu, jobvt, m, n, 
+    status = _libmagma.magma_dgesvd(jobu, jobvt, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(info))
     magmaCheckStatus(status)
 
@@ -1352,9 +1312,9 @@ def magma_cgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SVD decomposition.
     """
 
-    status = _libmagma.magma_cgesvd(jobu, jobvt, m, n, 
+    status = _libmagma.magma_cgesvd(jobu, jobvt, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(rwork),
                                     int(info))
     magmaCheckStatus(status)
@@ -1381,12 +1341,12 @@ def magma_zgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SVD decomposition.
     """
 
-    status = _libmagma.magma_zgesvd(jobu, jobvt, m, n, 
+    status = _libmagma.magma_zgesvd(jobu, jobvt, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(rwork), int(info))
     magmaCheckStatus(status)
-    
+
 # SGESDD, DGESDD, CGESDD, ZGESDD
 _libmagma.magma_sgesdd.restype = int
 _libmagma.magma_sgesdd.argtypes = [ctypes.c_int,
@@ -1409,9 +1369,9 @@ def magma_sgesdd(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SDD decomposition.
     """
 
-    status = _libmagma.magma_sgesdd(jobz, m, n, 
+    status = _libmagma.magma_sgesdd(jobz, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(iwork), int(info))
     magmaCheckStatus(status)
 
@@ -1436,9 +1396,9 @@ def magma_dgesdd(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SDD decomposition.
     """
 
-    status = _libmagma.magma_dgesdd(jobz, m, n, 
+    status = _libmagma.magma_dgesdd(jobz, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(iwork), int(info))
     magmaCheckStatus(status)
 
@@ -1464,9 +1424,9 @@ def magma_cgesdd(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SDD decomposition.
     """
 
-    status = _libmagma.magma_cgesdd(jobz, m, n, 
+    status = _libmagma.magma_cgesdd(jobz, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(rwork), int(iwork), int(info))
     magmaCheckStatus(status)
 
@@ -1492,9 +1452,336 @@ def magma_zgesdd(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork,
     SDD decomposition.
     """
 
-    status = _libmagma.magma_zgesdd(jobz, m, n, 
+    status = _libmagma.magma_zgesdd(jobz, m, n,
                                     int(a), lda, int(s), int(u), ldu,
-                                    int(vt), ldvt, int(work), lwork, 
+                                    int(vt), ldvt, int(work), lwork,
                                     int(rwork), int(iwork), int(info))
     magmaCheckStatus(status)
 
+
+
+# SPOSV, DPOSV, CPOSV, ZPOSV
+_libmagma.magma_sposv_gpu.restype = int
+_libmagma.magma_sposv_gpu.argtypes = [ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p]
+def magma_sposv_gpu(uplo, n, nhrs, a_gpu, lda, b_gpu, ldb):
+    """
+    Solve linear system with positive semidefinite coefficient matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_sposv_gpu(uplo, n, nhrs, int(a_gpu), lda,
+                                       int(b_gpu), ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+_libmagma.magma_dposv_gpu.restype = int
+_libmagma.magma_dposv_gpu.argtypes = _libmagma.magma_sposv_gpu.argtypes
+def magma_dposv_gpu(uplo, n, nhrs, a_gpu, lda, b_gpu, ldb):
+    """
+    Solve linear system with positive semidefinite coefficient matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_dposv_gpu(uplo, n, nhrs, int(a_gpu), lda,
+                                       int(b_gpu), ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_cposv_gpu.restype = int
+_libmagma.magma_cposv_gpu.argtypes = _libmagma.magma_sposv_gpu.argtypes
+def magma_cposv_gpu(uplo, n, nhrs, a_gpu, lda, b_gpu, ldb):
+    """
+    Solve linear system with positive semidefinite coefficient matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_cposv_gpu(uplo, n, nhrs, int(a_gpu), lda,
+                                       int(b_gpu), ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_zposv_gpu.restype = int
+_libmagma.magma_zposv_gpu.argtypes = _libmagma.magma_sposv_gpu.argtypes
+def magma_zposv_gpu(uplo, n, nhrs, a_gpu, lda, b_gpu, ldb):
+    """
+    Solve linear system with positive semidefinite coefficient matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_zposv_gpu(uplo, n, nhrs, int(a_gpu), lda,
+                                       int(b_gpu), ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+# SGESV, DGESV, CGESV, ZGESV
+_libmagma.magma_sgesv_gpu.restype = int
+_libmagma.magma_sgesv_gpu.argtypes = [ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p]
+def magma_sgesv_gpu(n, nhrs, A, lda, ipiv, B, ldb):
+    """
+    Solve system of linear equations.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_sgesv_gpu(n, nhrs, int(A), lda,
+                                   int(ipiv), int(B),
+                                   ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_dgesv_gpu.restype = int
+_libmagma.magma_dgesv_gpu.argtypes = _libmagma.magma_sgesv_gpu.argtypes
+def magma_dgesv_gpu(n, nhrs, A, lda, ipiv, B, ldb):
+    """
+    Solve system of linear equations.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_dgesv_gpu(n, nhrs, int(A), lda,
+                                   int(ipiv), int(B),
+                                   ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_cgesv_gpu.restype = int
+_libmagma.magma_cgesv_gpu.argtypes = _libmagma.magma_sgesv_gpu.argtypes
+def magma_cgesv_gpu(n, nhrs, A, lda, ipiv, B, ldb):
+    """
+    Solve system of linear equations.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_cgesv_gpu(n, nhrs, int(A), lda,
+                                   int(ipiv), int(B),
+                                   ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_zgesv_gpu.restype = int
+_libmagma.magma_zgesv_gpu.argtypes = _libmagma.magma_sgesv_gpu.argtypes
+def magma_zgesv_gpu(n, nhrs, A, lda, ipiv, B, ldb):
+    """
+    Solve system of linear equations.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_zgesv_gpu(n, nhrs, int(A), lda,
+                                   int(ipiv), int(B),
+                                   ldb, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+# SPOTRF, DPOTRF, CPOTRF, ZPOTRF
+_libmagma.magma_spotrf_gpu.restype = int
+_libmagma.magma_spotrf_gpu.argtypes = [ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p]
+def magma_spotrf_gpu(uplo, n, A, lda):
+    """
+    Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_spotrf_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_dpotrf_gpu.restype = int
+_libmagma.magma_dpotrf_gpu.argtypes = _libmagma.magma_spotrf_gpu.argtypes
+def magma_dpotrf_gpu(uplo, n, A, lda):
+    """
+    Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_dpotrf_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_cpotrf_gpu.restype = int
+_libmagma.magma_cpotrf_gpu.argtypes = _libmagma.magma_spotrf_gpu.argtypes
+def magma_cpotrf_gpu(uplo, n, A, lda):
+    """
+    Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_cpotrf_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_zpotrf_gpu.restype = int
+_libmagma.magma_zpotrf_gpu.argtypes = _libmagma.magma_zpotrf_gpu.argtypes
+def magma_zpotrf_gpu(uplo, n, A, lda):
+    """
+    Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_zpotrf_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+# SPOTRI, DPOTRI, CPOTRI, ZPOTRI
+_libmagma.magma_spotri_gpu.restype = int
+_libmagma.magma_spotri_gpu.argtypes = [ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p]
+def magma_spotri_gpu(uplo, n, A, lda):
+    """
+    Inverse using the Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_spotri_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_dpotri_gpu.restype = int
+_libmagma.magma_dpotri_gpu.argtypes = _libmagma.magma_spotri_gpu.argtypes
+def magma_dpotri_gpu(uplo, n, A, lda):
+    """
+    Inverse using the Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_dpotri_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_cpotri_gpu.restype = int
+_libmagma.magma_cpotri_gpu.argtypes = _libmagma.magma_spotri_gpu.argtypes
+def magma_cpotri_gpu(uplo, n, A, lda):
+    """
+    Inverse using the Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_cpotri_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_zpotri_gpu.restype = int
+_libmagma.magma_zpotri_gpu.argtypes = _libmagma.magma_spotri_gpu.argtypes
+def magma_zpotri_gpu(uplo, n, A, lda):
+    """
+    Inverse using the Cholesky factorization of positive symmetric matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    info = ctypes.c_int()
+    status = _libmagma.magma_zpotri_gpu(uplo, n, int(A), lda, ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+# SGETRF, DGETRF, CGETRF, ZGETRF
+_libmagma.magma_sgetrf_gpu.restype = int
+_libmagma.magma_sgetrf_gpu.argtypes = [ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_void_p]
+def magma_sgetrf_gpu(n, m, A, lda, ipiv):
+    """
+    LU factorization.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_sgetrf_gpu(n, m, int(A), lda,
+                                   int(ipiv), ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_dgetrf_gpu.restype = int
+_libmagma.magma_dgetrf_gpu.argtypes = _libmagma.magma_sgetrf_gpu.argtypes
+def magma_dgetrf_gpu(n, m, A, lda, ipiv):
+    """
+    LU factorization.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_dgetrf_gpu(n, m, int(A), lda,
+                                   int(ipiv), ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_cgetrf_gpu.restype = int
+_libmagma.magma_cgetrf_gpu.argtypes = _libmagma.magma_sgetrf_gpu.argtypes
+def magma_cgetrf_gpu(n, m, A, lda, ipiv):
+    """
+    LU factorization.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_cgetrf_gpu(n, m, int(A), lda,
+                                   int(ipiv), ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+_libmagma.magma_zgetrf_gpu.restype = int
+_libmagma.magma_zgetrf_gpu.argtypes = _libmagma.magma_sgetrf_gpu.argtypes
+def magma_zgetrf_gpu(n, m, A, lda, ipiv):
+    """
+    LU factorization.
+    """
+    info = ctypes.c_int()
+    status = _libmagma.magma_zgetrf_gpu(n, m, int(A), lda,
+                                   int(ipiv), ctypes.byref(info))
+    magmaCheckStatus(status)
+
+
+# SYMMETRIZE
+_libmagma.magmablas_ssymmetrize.restype = int
+_libmagma.magmablas_ssymmetrize.argtypes = [ctypes.c_int,
+                                  ctypes.c_int,
+                                  ctypes.c_void_p,
+                                  ctypes.c_int]
+def magmablas_ssymmetrize(uplo, n, A, lda):
+    """
+    Symmetrize a triangular matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    status = _libmagma.magmablas_ssymmetrize(uplo, n, int(A), lda)
+    magmaCheckStatus(status)
+
+
+_libmagma.magmablas_dsymmetrize.restype = int
+_libmagma.magmablas_dsymmetrize.argtypes = _libmagma.magmablas_ssymmetrize.argtypes
+def magmablas_dsymmetrize(uplo, n, A, lda):
+    """
+    Symmetrize a triangular matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    status = _libmagma.magmablas_dsymmetrize(uplo, n, int(A), lda)
+    magmaCheckStatus(status)
+
+
+_libmagma.magmablas_csymmetrize.restype = int
+_libmagma.magmablas_csymmetrize.argtypes = _libmagma.magmablas_ssymmetrize.argtypes
+def magmablas_csymmetrize(uplo, n, A, lda):
+    """
+    Symmetrize a triangular matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    status = _libmagma.magmablas_csymmetrize(uplo, n, int(A), lda)
+    magmaCheckStatus(status)
+
+
+_libmagma.magmablas_zsymmetrize.restype = int
+_libmagma.magmablas_zsymmetrize.argtypes = _libmagma.magmablas_ssymmetrize.argtypes
+def magmablas_zsymmetrize(uplo, n, A, lda):
+    """
+    Symmetrize a triangular matrix.
+    """
+    uplo = _uplo_conversion[uplo]
+    status = _libmagma.magmablas_zsymmetrize(uplo, n, int(A), lda)
+    magmaCheckStatus(status)

--- a/scikits/cuda/magma.py
+++ b/scikits/cuda/magma.py
@@ -47,12 +47,6 @@ def magma_strerror(error):
 
     return _libmagma.magma_strerror(error)
 
-class magmaError(Exception):
-    try:
-        __doc__ = magma_strerror(-100)
-    except:
-        pass
-    pass
 
 class MagmaError(Exception):
 	def __init__(self, status, info=None):
@@ -61,89 +55,14 @@ class MagmaError(Exception):
 		errstr = "%s (Code: %d)" % (magma_strerror(status), status)
 		super(MagmaError,self).__init__(errstr)
 
-class MagmaNotInitializedError(MagmaError):
-    pass
 
-class MagmaReinitializedError(MagmaError):
-    pass
-
-class MagmaNotSupportedError(MagmaError):
-    pass
-
-class MagmaIllegalValueError(MagmaError):
-    pass
-
-class MagmaIllegalValueError(MagmaError):
-    pass
-
-class MagmaNotFoundError(MagmaError):
-    pass
-
-class MagmaAllocationError(MagmaError):
-    pass
-
-class MagmaInternalLimitError(MagmaError):
-    pass
-
-class MagmaUnallocatedError(MagmaError):
-    pass
-
-class MagmaFilesystemError(MagmaError):
-    pass
-
-class MagmaUnexpectedError(MagmaError):
-    pass
-
-class MagmaSequenceFlushedError(MagmaError):
-    pass
-
-class MagmaHostAllocError(MagmaError):
-    pass
-
-class MagmaDeviceAllocError(MagmaError):
-    pass
-
-class MagmaCUDAStreamError(MagmaError):
-    pass
-
-class MagmaInvalidPtrError(MagmaError):
-    pass
-
-class MagmaUnknownError(MagmaError):
-    pass
-
-magmaExceptions = {
-    -100: MagmaError,
-    -101: MagmaNotInitializedError,
-    -102: MagmaReinitializedError,
-    -103: MagmaNotSupportedError,
-    -104: MagmaIllegalValueError,
-    -105: MagmaNotFoundError,
-    -106: MagmaAllocationError,
-    -107: MagmaInternalLimitError,
-    -108: MagmaUnallocatedError,
-    -109: MagmaFilesystemError,
-    -110: MagmaUnexpectedError,
-    -111: MagmaSequenceFlushedError,
-    -112: MagmaHostAllocError,
-    -113: MagmaDeviceAllocError,
-    -114: MagmaCUDAStreamError,
-    -115: MagmaInvalidPtrError,
-    -116: MagmaUnknownError
-}
-
-_libmagma.magma_uplo_const.restype = ctypes.c_int
-_libmagma.magma_uplo_const.argtypes = [ctypes.c_char]
 def magmaCheckStatus(status):
     """
     Raise an exception corresponding to the specified MAGMA status code.
     """
 
     if status != 0:
-        try:
-            raise magmaExceptions[status](status)
-        except KeyError:
-            raise MagmaError(status)
+        raise MagmaError(status)
 
 # Utility functions:
 _libmagma.magma_version.argtypes = [ctypes.c_void_p,
@@ -161,6 +80,9 @@ def magma_version():
         ctypes.byref(minv), ctypes.byref(micv))
     return (majv.value, minv.value, micv.value)
 
+
+_libmagma.magma_uplo_const.restype = ctypes.c_int
+_libmagma.magma_uplo_const.argtypes = [ctypes.c_char]
 _libmagma.magma_init.restype = int
 def magma_init():
     """


### PR DESCRIPTION
This PR adds wrappers for the gpu-versions of *GETRF, *GESV, *POSV, *POTRF, *POTRI and *SYMMETRIZE.

It also changes the error handling, so that each exception always contains the relevant error string + code, but no more specific exceptions are thrown for each magma error code (those codes seem to change each version anyhow, at least the ones that were present were outdated in magma 1.6).
