### PR TITLE
Warn when trying to compute skcuda.misc.argmax/argmin without axis

### DIFF
--- a/scikits/cuda/magma.py
+++ b/scikits/cuda/magma.py
@@ -96,10 +96,10 @@ def magma_init():
     magmaCheckStatus(status)
     v = magma_version()
     if v >= (1, 5, 0):
-        _uplo_conversion.update({"L": _libmagma.magma_uplo_const("L"),
-                                 "l": _libmagma.magma_uplo_const("l"),
-                                 "U": _libmagma.magma_uplo_const("U"),
-                                 "u": _libmagma.magma_uplo_const("u")})
+        _uplo_conversion.update({"L": _libmagma.magma_uplo_const(b"L"),
+                                 "l": _libmagma.magma_uplo_const(b"l"),
+                                 "U": _libmagma.magma_uplo_const(b"U"),
+                                 "u": _libmagma.magma_uplo_const(b"u")})
     else:
        _uplo_conversion.update({"L": "L", "l": "l", "U": "u", "u": "u"})
 

--- a/scikits/cuda/misc.py
+++ b/scikits/cuda/misc.py
@@ -1288,9 +1288,9 @@ def _minmax_impl(a_gpu, axis, min_or_max, stream=None):
 
     if axis is None:  ## Note: PyCUDA doesn't have an overall argmax/argmin!
         if min_or_max == 'max':
-            return gpuarray.max(a_gpu).get()
+            return gpuarray.max(a_gpu).get(), None
         else:
-            return gpuarray.min(a_gpu).get()
+            return gpuarray.min(a_gpu).get(), None
     else:
         if axis < 0:
             axis += 2
@@ -1370,6 +1370,8 @@ def argmax(a_gpu, axis):
     out : pycuda.gpuarray.GPUArray or float
         Array of indices into the array.
     '''
+    if axis is None:
+        raise NotImplementedError("Can't compute global argmax")
     return _minmax_impl(a_gpu, axis, "max")[1]
 
 
@@ -1389,6 +1391,8 @@ def argmin(a_gpu, axis):
     out : pycuda.gpuarray.GPUArray or float
         Array of indices into the array.
     '''
+    if axis is None:
+        raise NotImplementedError("Can't compute global argmax")
     return _minmax_impl(a_gpu, axis, "min")[1]
 
 


### PR DESCRIPTION
`skcuda.misc.argmax/argmin` don't work if you don't specify an axis (i.e., there is no implementation of calculating the global argmin/argmax yet). This PR throws an exception when a user tries to do it nevertheless.